### PR TITLE
Enhance Download Options: Chapter & Lecture Filtering and SRT Conversion

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -141,3 +141,13 @@ def format_time(seconds):
     hours, remainder = divmod(seconds, 3600)
     minutes, seconds = divmod(remainder, 60)
     return f"{hours}hr {minutes}min {seconds}s" if hours > 0 else f"{minutes}min {seconds}s"
+
+def is_valid_chapter(mindex, start_chapter, end_chapter):
+    return start_chapter <= mindex <= end_chapter
+
+def is_valid_lecture(mindex, lindex, start_chapter, start_lecture, end_chapter, end_lecture):
+    if mindex == start_chapter and lindex < start_lecture:
+        return False
+    if mindex == end_chapter and lindex > end_lecture:
+        return False
+    return True

--- a/main.py
+++ b/main.py
@@ -132,7 +132,7 @@ class Udemy:
                     'children': []
                 }
                 curriculum.append(current_chapter)
-            elif item['_class'] in ['lecture', 'practice']:
+            elif item['_class'] == 'lecture':
                 if current_chapter is not None:
                     current_chapter['children'].append(item)
                     if item['_class'] == 'lecture':

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ requests==2.32.3
 rich==13.8.1
 tqdm==4.66.5
 urllib3==2.2.3
+webvtt-py==0.5.1

--- a/utils/process_captions.py
+++ b/utils/process_captions.py
@@ -1,7 +1,8 @@
 import os
 import requests
+import webvtt
 
-def download_captions(captions, download_folder_path, title_of_output_mp4, captions_list):
+def download_captions(captions, download_folder_path, title_of_output_mp4, captions_list, convert_to_srt):
     filtered_captions = [caption for caption in captions if caption["locale_id"] in captions_list]
 
     for caption in filtered_captions:
@@ -9,8 +10,15 @@ def download_captions(captions, download_folder_path, title_of_output_mp4, capti
         response.raise_for_status()
         if caption['file_name'].endswith('.vtt'):
             caption_name = f"{title_of_output_mp4} - {caption['video_label']}.vtt"
-            with open(os.path.join(download_folder_path, caption_name), 'wb') as file:
+            vtt_path = os.path.join(download_folder_path, caption_name)
+            with open(vtt_path, 'wb') as file:
                 file.write(response.content)
+
+            if convert_to_srt:
+                srt_name = caption_name.replace('.vtt', '.srt')
+                srt_path = os.path.join(download_folder_path, srt_name)
+                srt_content = webvtt.read(vtt_path)
+                srt_content.save_as_srt(srt_path)
+                
         else:
-            pass
-            # Only VTT captions are supported. Please create a github issue if you'd like to add support for other formats. 
+            print("Only VTT captions are supported. Please create a github issue if you'd like to add support for other formats.")


### PR DESCRIPTION
This pull request introduces minor changes to enhance the downloading functionality of the script.

### 1. Chapter and Lecture Filtering:
We have added flags to filter chapters and lectures, as asked in this issue #4.

The following flags have been implemented:
`--start-chapter 5`: Start the download from the specified chapter.
`--start-lecture 1`: Start the download from the specified lecture.
`--end-chapter 5`: End the download at the specified chapter.
`--end-lecture 7`: End the download at the specified lecture.

For instance, you can think of `--start-chapter` as marking a starting point on a timeline of lectures and the `--end-chapter` flag acts like a destination point, defining where the download should stop.

The `--start-lecture` and `--end-lecture` flags further refine this by allowing you to specify exact lectures within those chapters.

### 2. SRT Conversion
We have also added support for converting captions to SRT format using the flag `--srt`, as asked in issue #10.